### PR TITLE
Atom is obsolete, so remove references

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -106,20 +106,20 @@ We're aware of the sites below, and we've made progress on some, but they're not
 First, your site needs to support <a href="http://www.webmention.org/">webmentions</a>. <a href="https://indieweb.org/webmention#Publishing_Software">Check out the IndieWeb wiki</a> for instructions for your web server.
 </p>
 
-<p>
-Next, add an <a href="https://en.wikipedia.org/wiki/Atom_(standard)">Atom</a> feed if your site doesn't already have one. If you're on <a href="https://wordpress.org/">WordPress</a>, install the <a href="https://wordpress.org/plugins/atom-default-feed/">Atom Default Feed plugin</a>.
+<!--<p>
+Next, add an <a href="https://en.wikipedia.org/wiki/Atom_(standard)">Atom</a> feed if your site doesn't already have one. If you're on <a href="https://wordpress.org/">WordPress</a>, install the <a href="https://wordpress.org/plugins/atom-default-feed/">Atom Default Feed plugin</a>.-->
  <!-- or just <a href="https://codex.wordpress.org/WordPress_Feeds#Finding_Your_Feed_URL">add this</a> to your HTML header:<br /> -->
-Otherwise, you can use <a href="https://granary.io/">granary</a>. Just add this to your site's HTML <code>&lt;head&gt;</code> and fill in <code>DOMAIN</code> with your site's domain:
+<!--Otherwise, you can use <a href="https://granary.io/">granary</a>. Just add this to your site's HTML <code>&lt;head&gt;</code> and fill in <code>DOMAIN</code> with your site's domain:
 </p>
 <pre>&lt;link rel="alternate" type="application/atom+xml"
       href="https://granary.io/url?url=http://[DOMAIN]/&input=html&output=atom&hub=https://bridgy-fed.superfeedr.com/" /&gt;</pre>
 
 <p>
 If you want people on fedsocnets to see your posts, your site will also need to support <a href="https://indieweb.org/WebSub">WebSub</a> (née PubSubHubbub). Specifically, <a href="https://blog.superfeedr.com/howto-pubsubhubbub/#discovery">your Atom feed needs to advertise it</a>. <a href="https://github.com/tootsuite/mastodon/issues/1441#issuecomment-302969948">Example details for Mastodon.</a> If you're on a CMS, it may already have a plugin! <a href="https://wordpress.org/">WordPress</a> has <a href="https://indieweb.org/WebSub#WordPress_Plugins_for_PuSH">a couple</a>, and <a href="http://withknown.com/">Known</a> has it <a href="https://indieweb.org/WebSub#1000s_of_Known_Sites">built in</a>. Or you can use <a href="https://superfeedr.com/publisher">Superfeedr</a> or <a href="https://switchboard.p3k.io/">Switchboard</a>.
-</p>
+</p>-->
 
 <p>
-Finally, configure your web site to redirect these URL paths to the same paths on <code>https://fed.brid.gy/</code>, including query parameters:
+Next, configure your web site to redirect these URL paths to the same paths on <code>https://fed.brid.gy/</code>, including query parameters:
 </p>
 <pre>
 /.well-known/host-meta
@@ -180,11 +180,11 @@ https://en.support.wordpress.com/site-redirect/
 <li class="answer">
 
 <p>
-Federated social network identities take the form <code>@username@example.com</code>, like an email address with a leading <code>@</code>. Your site's identity via Bridgy Fed will be <code>@yourdomain.com@yourdomain.com</code>. Once you've <a href="#setup">set up Atom and WebSub on your site</a>, people can follow you at that address.
+Federated social network identities take the form <code>@username@example.com</code>, like an email address with a leading <code>@</code>. Your site's identity via Bridgy Fed will be <code>@yourdomain.com@yourdomain.com</code>. <!--Once you've <a href="#setup">set up Atom and WebSub on your site</a>, people can follow you at that address.-->
 </p>
 
 <p>
-Most fedsocnets also publish Atom themselves, so you can add profile URLs like <a href="https://mastodon.technology/@snarfed">mastodon.technology/@snarfed</a> to your <a href="https://indieweb.org/reader">reader</a> and see their posts there too.
+Most fedsocnets publish Atom themselves, or even use Microformats, so you can add profile URLs like <a href="https://mastodon.technology/@snarfed">mastodon.technology/@snarfed</a> to your <a href="https://indieweb.org/reader">reader</a> and see their posts there too.
 </p>
 
 <p>


### PR DESCRIPTION
As far as I can see, we don't really need Atom anymore for the setup, at least with Mastodon. In case others use them, then you can totally ignore this request of course :)

Didn't remove the docs completely, only commented them out for now.