### PR TITLE
one line htaccess setup option

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -175,10 +175,12 @@ Finally, configure your web site to redirect these URL paths to the same paths o
 <li><em><a href="http://withknown.com/">Known</a></em> or <em><a href="https://drupal.org/project/indieweb">Drupal</a></em>: follow the <a href="#apache">Apache</a> or <a href="#nginx">nginx</a> instructions below.
 </li>
 
-<li id="apache"><em><a href="http://httpd.apache.org/">Apache</a></em>: add this to your <code>.htaccess</code> file:<br />
+<li id="apache"><em><a href="http://httpd.apache.org/">Apache</a></em>: add this to your <code>.htaccess</code> file:
   <pre>RewriteEngine on
-  RewriteBase /
-  RewriteRule ^.well-known/(host-meta|webfinger).* https://fed.brid.gy/$0  [redirect=302,last]</pre>
+RewriteBase /
+RewriteRule ^.well-known/(host-meta|webfinger).* https://fed.brid.gy/$0  [redirect=302,last]</pre>
+ or if your top level <code>.htaccess</code> file already has <code>RewriteEngine on</code>, you may add just this one line:
+ <pre>RewriteRule ^.well-known/(host-meta|webfinger).* https://fed.brid.gy/$0  [redirect=302,last]</pre>
 </li>
 
 <li id="nginx"><em><a href="https://nginx.org/">nginx</a></em>: add this to your <code>nginx.conf</code> file, in the <code>server</code> section:<br />


### PR DESCRIPTION
if your htaccess already has RewriteEngine on, you only need a one-liner for configuring Bridgy Fed for discovery and following. also pruned some spaces in the 3-liner code for Apache. no need for a br right before a pre tag