### PR TITLE
Allow providing a URL fragment for posts

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -9,6 +9,7 @@
 <li><a href="#use">How do I use it?</a></li>
 <li><a href="#setup">How do I set it up?</a></li>
 <li><a href="#image">How do I include an image in a post?</a></li>
+<li><a href="#fragment">Can I publish just one part of a page?</a></li>
 <li><a href="#discovery">How can people on the fediverse find me?</a></li>
 <li><a href="#troubleshooting">I tried it, and it didn't work!</a></li>
 <li><a href="#cost">How much does it cost?</a></li>
@@ -186,6 +187,16 @@ Use <code>&lt;img class="u-photo"&gt;</code> for the image in your post. For exa
 I love scotch. Scotchy scotchy scotch.
 </pre>
 </p>
+</li>
+
+<li id="fragment" class="question">Can I publish just one part of a page?</li>
+<li class="answer">
+<p>If that HTML element has its own id, then sure! Just put the id in the fragment of the URL that you publish. For example, to publish the <code>bar</code> post here:</p>
+<pre>&lt;div id="<span class='value'>a</span>" class="<span class='keyword'>h-entry</span>"&gt;<span class='value'>foo</span>&lt;/div&gt;
+&lt;div id="<span class='value'>b</span>" class="<span class='keyword'>h-entry</span>"&gt;<span class='value'>bar</span>&lt;/div&gt;
+&lt;div id="<span class='value'>c</span>" class="<span class='keyword'>h-entry</span>"&gt;<span class='value'>baz</span>&lt;/div&gt;
+</pre>
+<p>...just add the id to your page's URL in a fragment, e.g. <code>http://site/post#b</code> here.</p>
 </li>
 
 <li id="discovery" class="question">How can people on the fediverse find me?</li>

--- a/webmention.py
+++ b/webmention.py
@@ -48,7 +48,8 @@ class Webmention(View):
         source_resp = common.requests_get(source)
         self.source_url = source_resp.url or source
         self.source_domain = urllib.parse.urlparse(self.source_url).netloc.split(':')[0]
-        self.source_mf2 = util.parse_mf2(source_resp)
+        fragment = urllib.parse.urlparse(self.source_url).fragment
+        self.source_mf2 = util.parse_mf2(source_resp, id=fragment)
 
         # logger.debug(f'Parsed mf2 for {source_resp.url} : {json_dumps(self.source_mf2 indent=2)}')
 
@@ -64,7 +65,7 @@ class Webmention(View):
         if not entry:
             error(f'No microformats2 found on {self.source_url}')
 
-        logger.info(f'First entry: {json_dumps(entry, indent=2)}')
+        logger.info(f'First entry (id={fragment}: {json_dumps(entry, indent=2)}')
         # make sure it has url, since we use that for AS2 id, which is required
         # for ActivityPub.
         props = entry.setdefault('properties', {})


### PR DESCRIPTION

A number of folks use a single page for multiple posts, using a URL
Fragment parameter to denote which of the posts on the given page should
be used, and are used to this experience with Bridgy.

To allow use of this on Bridgy Fed, too, we can add support for
discovering the ID of the `h-entry` to be Webmention'd in the same way
that we do with [Bridgy].

This largely copies the structure of the existing tests, copying
`test_activitypub_follow`, and adding in multiple posts on the page.

For debugging purposes, we can make sure to log out the `fragment`.

[Bridgy]: https://github.com/snarfed/bridgy/commit/f760c0d10e4d28a84585dbbff259eff42466e119

