### PR TITLE
Fix to nginx .well-known snippet.

### DIFF
--- a/templates/docs.html
+++ b/templates/docs.html
@@ -131,7 +131,7 @@ RewriteRule ^.well-known/(host-meta|webfinger).* https://fed.brid.gy/$0  [redire
 </li>
 
 <li id="nginx"><em><a href="https://nginx.org/">nginx</a></em>: add this to your <code>nginx.conf</code> file, in the <code>server</code> section:<br />
-  <pre>rewrite ^/.well-known/(host-meta|webfinger).* https://fed.brid.gy$request_uri redirect;</pre>
+  <pre>rewrite ^/\.well-known/(host-meta|webfinger).* https://fed.brid.gy$request_uri redirect;</pre>
 </li>
 
 <!--


### PR DESCRIPTION
I noticed that the nginx snippet doesn't have the leading '.' escaped in the regexp. This means that any nginx servers won't redirect for `webfinger` and `host-meta`. Added an escape to the regexp.