### PR TITLE
Docs fix nginx setup

### DIFF
--- a/templates/docs.html
+++ b/templates/docs.html
@@ -102,7 +102,7 @@ RewriteRule ^.well-known/(host-meta|webfinger).* https://fed.brid.gy/$0  [redire
 </li>
 
 <li id="nginx"><em><a href="https://nginx.org/">nginx</a></em>: add this to your <code>nginx.conf</code> file, in the <code>server</code> section:<br />
-  <pre>rewrite ^/\.well-known/(host-meta|webfinger).* https://fed.brid.gy$request_uri redirect;</pre>
+  <pre>rewrite ^/\.well-known/(host-meta|webfinger).* https://fed.brid.gy$request_uri? redirect;</pre>
 </li>
 
   <li id="netlify"><em><a href="https://docs.netlify.com/routing/redirects/">Netlify</a></em>: add this to your <code>netlify.toml</code> file.


### PR DESCRIPTION
This is a single character change to the docs.

The existing config gives query string twice in `Location`. This is because query strings are passed by default and are also included in the `$request_uri` variable.