### PR TITLE
real tag link instead of example.com

### DIFF
--- a/templates/docs.html
+++ b/templates/docs.html
@@ -364,8 +364,8 @@ I love scotch. Scotchy scotchy scotch.
 
 <pre>&lt;div class="<span class='keyword'>h-entry</span>"&gt;
   &lt;p class="<span class='keyword'>e-content</span>"&gt;
-    just setting up my feddr
-    &lt;a href="<span class='value'>https://example.com/tag/throwback</span>" class="<span class='keyword'>p-category</span>"&gt;<span class='value'>#throwback</span>&lt;/a&gt;
+    chasing the fun laser
+    &lt;a href="<span class='value'>https://indieweb.social/tags/caturday</span>" class="<span class='keyword'>p-category</span>"&gt;<span class='value'>#caturday</span>&lt;/a&gt;
   &lt;/p&gt;
 &lt;/div&gt;
 </pre>


### PR DESCRIPTION
use a real tag destination and hashtag instead of example.com