### PR TITLE
Swap entries of @bsky.brid.gy@bsky.brid.gy's `url` property

### DIFF
--- a/bsky.brid.gy.as2.json
+++ b/bsky.brid.gy.as2.json
@@ -7,8 +7,8 @@
   "type": "Application",
   "id": "https://bsky.brid.gy/bsky.brid.gy",
   "url": [
-    "https://fed.brid.gy/",
-    "https://bsky.brid.gy/"
+    "https://bsky.brid.gy/",
+    "https://fed.brid.gy/"
   ],
   "preferredUsername": "bsky.brid.gy",
   "summary": "<p><a href='https://fed.brid.gy/'>Bridgy Fed</a> bot user for <a href='https://bsky.social/'>Bluesky</a>. To bridge your fediverse account to Bluesky, follow this account. <a href='https://fed.brid.gy/docs'>More info here.</a><p>After you follow this account, it will follow you back. Accept its follow to make sure your fediverse posts get sent to the bridge and make it into Bluesky.<p>To ask a Bluesky user to bridge their account, DM their handle (eg snarfed.bsky.social) to this account.</p>",


### PR DESCRIPTION
Workaround for GoToSocial. See https://github.com/snarfed/bridgy-fed/issues/1033#issuecomment-2395129612

While the underlying problem will likely be fixed there before long (see https://github.com/superseriousbusiness/gotosocial/issues/3381), adding this workaround here on our end would at least allow testing against GoToSocial instances that either fetched `@fed.brid.gy@fed.brid.gy` first or don't know of either bridge account yet.

(Other instances would currently require an `Update`-`Application` targeting `https://bsky.brid.gy/bsky.brid.gy` to become unstuck.)