### PR TITLE
URL for a bluesky account bridged to the fediverse

### DIFF
--- a/activitypub.py
+++ b/activitypub.py
@@ -21,6 +21,7 @@ import requests
 from requests import TooManyRedirects
 from requests.models import DEFAULT_REDIRECT_LIMIT
 from werkzeug.exceptions import BadGateway
+import atproto
 
 from flask_app import app
 import common
@@ -590,6 +591,17 @@ class ActivityPub(User, Protocol):
                     return cls._load_key(owner, follow_owner=False)
 
         return actor
+
+    @classmethod
+    def bridged_web_url_for(cls, user, fallback=False):
+        """Returns a bridged user's profile URL on ``https://bsky.brid.gy/r/*``.
+
+        For example, returns ``https://bsky.brid.gy/r/https://bsky.app/profile/alice.bsky.social``
+        for BlueSky user ``alice.bsky.social``.
+        """
+        if isinstance(user, atproto.ATProto):
+            return f"https://bsky.brid.gy/r/{user.web_url()}"
+        return super().bridged_web_url_for(user, fallback)
 
 
 def signed_get(url, from_user=None, **kwargs):


### PR DESCRIPTION
hi hello

This is mostly a proposal made as a pull request because I don't know the source code of bridgy-fed or the protocols much, and because I couldn't make a Cloud SDK account to modify and run the tests sowwy. So there's probably things to change.

I've seen that for the message `@blueskyuser@bsky.brid.gy is already bridged into the fediverse.` (that I received on fedi about a bluesky profile), the user wasn't a link. That made me sad so I tried to modify that.

I added ActivityPub.bridged_web_url_for() that works for any BlueSky account and returns a url like `https://bsky.brid.gy/r/https://bsky.app/profile/blueskyuser.bsky.social`. That's the type of url I get if I post something mentioning a bsky.brid.gy account from the fediverse.
 
The code I added is way smaller than this description

thanks :))