### PR TITLE
Update atproto.py

### DIFF
--- a/atproto.py
+++ b/atproto.py
@@ -960,9 +960,9 @@ class ATProto(User, Protocol):
 
         if from_user.LABEL == 'web':
             # link web users to their user pages
-            source_links = f'[bridged from {url}{proto_phrase}: https://{PRIMARY_DOMAIN}{from_user.user_page_path()} ]'
+            source_links = f'[bridged from {url}{proto_phrase}: https://{PRIMARY_DOMAIN}{from_user.user_page_path()}]'
         else:
-            source_links = f'[bridged from {url}{proto_phrase} by https://{PRIMARY_DOMAIN}/ ]'
+            source_links = f'[bridged from {url}{proto_phrase} by https://{PRIMARY_DOMAIN}/]'
 
         if summary:
             source_links = '\n\n' + source_links


### PR DESCRIPTION
There is an extra space in the bridged profile text on bluesky that looks like this:

> [bridged from [solarsystem.social/@mrak](https://solarsystem.social/@mrak) on the fediverse by [fed.brid.gy](https://fed.brid.gy/) ]


I think that this PR fixes this minor annoyance.