### PR TITLE
docs: fix block/unblock command links

### DIFF
--- a/templates/docs.html
+++ b/templates/docs.html
@@ -386,8 +386,8 @@
 <li><em>username [domain]</em>: <a href="#enhanced">set a custom domain username (aka handle)</a>
 <li><em>[handle]</em>: <a href="#dm-request">ask it to DM a user to request that they bridge their account</a>
 <li><em>did</em>: get your bridged Bluesky account's <a href="https://atproto.com/guides/identity#identifiers">DID</a> (only supported with the Bluesky bot)
-<li><em>block [handle]</em>: <a href="#">block a user on another network who's not bridged into your network</a>
-<li><em>unblock [handle]</em>: <a href="#">unblock a user on another network who's not bridged into your network</a>
+<li><em>block [handle]</em>: <a href="#block">block a user on another network who's not bridged into your network</a>
+<li><em>unblock [handle]</em>: <a href="#block">unblock a user on another network who's not bridged into your network</a>
 </ul>
 </li>
 


### PR DESCRIPTION
Just something I noticed while reading the docs.

(I'm assuming this is the right place to point those links looking at the other ones)