### PR TITLE
pages.login_to_user_key: use oauth-dropins rather than direct JSON

### DIFF
--- a/pages.py
+++ b/pages.py
@@ -219,7 +219,7 @@ def login_to_user_key(login):
         case 'Bluesky':
             return ATProto(id=login.key.id()).key
         case 'Mastodon':
-            if (id := login.actor_id()):
+            if id := login.actor_id():
                 return ActivityPub(id=id).key
             logger.warning(f'Mastodon auth entity {login.key.id()} has no user_json or uri')
             return None


### PR DESCRIPTION
As found in the course of debugging #2339, along with another case of direct JSON access.  Note that I have *not* run any tests for this yet since getting the venv set up has been surprisingly painful on FreeBSD (the `secp256k1` dependency build runs into a malformed `cc` line, despite the system `math/py-secp256k1` building just fine; currently trying to get a wheel out of the latter to shove into the venv).